### PR TITLE
Proxy the dependencies in the URL generation command

### DIFF
--- a/Iazel/RegenProductUrl/etc/di.xml
+++ b/Iazel/RegenProductUrl/etc/di.xml
@@ -14,4 +14,11 @@
             </argument>
         </arguments>
     </type>
+    <type name="Iazel\RegenProductUrl\Console\Command\RegenerateProductUrlCommand">
+        <arguments>
+            <argument name="state" xsi:type="object">Magento\Framework\App\State\Proxy</argument>
+            <argument name="collection" xsi:type="object">Magento\Catalog\Model\ResourceModel\Product\Collection\Proxy</argument>
+            <argument name="productUrlRewriteGenerator" xsi:type="object">Magento\CatalogUrlRewrite\Model\ProductUrlRewriteGenerator\Proxy</argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
With Magento 2.1.8+ CLI commands are constructed when the CLI client is
invoked. Additionally, DI will construct any objects that those commands
type in their constructors, so on and so fourth down the stack.

The problem is, this extension may exist in an environment in which the
store is not yet installed, and the database is thus unavailable. A
common place this is used is in 2.1.x in CI, as the database is required
in order to generate static content.

This commit proxies the dependencies of this constructor, such that the
constructor can be used (and thus appear in the CLI menu) but not
invoked while the store is not installed.